### PR TITLE
fix: update README files with correct yarn install commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ npm install --save vitepress-theme-async
 or
 
 ```bash
-yarn add --save vitepress-theme-async
+yarn add vitepress-theme-async
 ```
 
 ## Upgrade

--- a/README_zh-CN.md
+++ b/README_zh-CN.md
@@ -54,7 +54,7 @@ npm install --save vitepress-theme-async
 或者
 
 ```bash
-yarn add --save vitepress-theme-async
+yarn add vitepress-theme-async
 ```
 
 ## 更新


### PR DESCRIPTION
两份 Readme 文件里都错误地使用了`yarn add --save`，已修改为正确的`yarn add vitepress-theme-async`。
Both README files incorrectly use `yarn add --save`. This has been corrected to the proper usage: `yarn add vitepress-theme-async`.